### PR TITLE
Correct typo

### DIFF
--- a/src/epub/text/chapter-13.xhtml
+++ b/src/epub/text/chapter-13.xhtml
@@ -20,7 +20,7 @@
 			<p>“I remain⁠—if I am strong enough,” asserted the sallow little Professor, whose large ears, thin like membranes, and standing far out from the sides of his frail skull, took on suddenly a deep red tint.</p>
 			<p>“Haven’t I suffered enough from this oppression of the weak?” he continued forcibly. Then tapping the breast-pocket of his jacket: “And yet <em>I am</em> the force,” he went on. “But the time! The time! Give me time! Ah! that multitude, too stupid to feel either pity or fear. Sometimes I think they have everything on their side. Everything⁠—even death⁠—my own weapon.”</p>
 			<p>“Come and drink some beer with me at the Silenus,” said the robust Ossipon after an interval of silence pervaded by the rapid flap, flap of the slippers on the feet of the Perfect Anarchist. This last accepted. He was jovial that day in his own peculiar way. He slapped Ossipon’s shoulder.</p>
-			<p>“Beer! So be it! Let us drink and he merry, for we are strong, and tomorrow we die.”</p>
+			<p>“Beer! So be it! Let us drink and be merry, for we are strong, and tomorrow we die.”</p>
 			<p>He busied himself with putting on his boots, and talked meanwhile in his curt, resolute tones.</p>
 			<p>“What’s the matter with you, Ossipon? You look glum and seek even my company. I hear that you are seen constantly in places where men utter foolish things over glasses of liquor. Why? Have you abandoned your collection of women? They are the weak who feed the strong⁠—eh?”</p>
 			<p>He stamped one foot, and picked up his other laced boot, heavy, thick-soled, unblacked, mended many times. He smiled to himself grimly.</p>


### PR DESCRIPTION
In chapter 13, the Professor says "Let us drink and *he* merry," It was "be merry," in the original. This error is not present in the Project Gutenberg source.